### PR TITLE
always use ValidationMethod=DNS

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2023-02-10T00:03:07Z"
-  build_hash: d0f3d78cbea8061f822cbceac3786128f091efe6
-  go_version: go1.19
-  version: v0.24.2
+  build_date: "2023-02-17T15:23:41Z"
+  build_hash: 3c89a32e92496e196b6a1d213d338f4e37b37926
+  go_version: go1.19.4
+  version: v0.24.2-2-g3c89a32
 api_directory_checksum: 202e02932e71256f27a9cd0f6454e508c5b7e9b6
 api_version: v1alpha1
 aws_sdk_go_version: v1.44.177
 generator_config_info:
-  file_checksum: cf8ed525d9422f011b706c0edf1984d5f70853e5
+  file_checksum: 5394dff577561d72517cec97192a6d2ea88f4244
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -6,14 +6,6 @@ operations:
   RequestCertificate:
     resource_name: Certificate
     operation_type: CREATE
-    override_values:
-      # NOTE(jaypipes): We only support DNS-based validation, because
-      # certificate renewal is not really automatable when email verification
-      # is used.
-      #
-      # See discussion here:
-      # https://docs.aws.amazon.com/acm/latest/userguide/email-validation.html
-      ValidationMethod: DNS
   # NOTE(jaypipes): There is a GetCertificate API call, but that returns the
   # actual cert bytes, not the attributes of the certificate request
   DescribeCertificate:
@@ -27,6 +19,18 @@ resources:
     hooks:
       sdk_create_pre_build_request:
         template_path: hooks/certificate/sdk_create_pre_build_request.go.tpl
+      sdk_create_post_build_request:
+        # NOTE(jaypipes): We only support DNS-based validation, because
+        # certificate renewal is not really automatable when email verification
+        # is used.
+        #
+        # See discussion here:
+        # https://docs.aws.amazon.com/acm/latest/userguide/email-validation.html
+        #
+        # Unfortunately, because fields in the "ignore" configuration list are
+        # now deleted from the aws-sdk-go private/model/api.Shape object,
+        # setting `override_values` above does not work :(
+        code: input.SetValidationMethod("DNS")
     exceptions:
       terminal_codes:
         - InvalidParameter

--- a/generator.yaml
+++ b/generator.yaml
@@ -6,14 +6,6 @@ operations:
   RequestCertificate:
     resource_name: Certificate
     operation_type: CREATE
-    override_values:
-      # NOTE(jaypipes): We only support DNS-based validation, because
-      # certificate renewal is not really automatable when email verification
-      # is used.
-      #
-      # See discussion here:
-      # https://docs.aws.amazon.com/acm/latest/userguide/email-validation.html
-      ValidationMethod: DNS
   # NOTE(jaypipes): There is a GetCertificate API call, but that returns the
   # actual cert bytes, not the attributes of the certificate request
   DescribeCertificate:
@@ -27,6 +19,18 @@ resources:
     hooks:
       sdk_create_pre_build_request:
         template_path: hooks/certificate/sdk_create_pre_build_request.go.tpl
+      sdk_create_post_build_request:
+        # NOTE(jaypipes): We only support DNS-based validation, because
+        # certificate renewal is not really automatable when email verification
+        # is used.
+        #
+        # See discussion here:
+        # https://docs.aws.amazon.com/acm/latest/userguide/email-validation.html
+        #
+        # Unfortunately, because fields in the "ignore" configuration list are
+        # now deleted from the aws-sdk-go private/model/api.Shape object,
+        # setting `override_values` above does not work :(
+        code: input.SetValidationMethod("DNS")
     exceptions:
       terminal_codes:
         - InvalidParameter

--- a/pkg/resource/certificate/sdk.go
+++ b/pkg/resource/certificate/sdk.go
@@ -372,6 +372,7 @@ func (rm *resourceManager) sdkCreate(
 	if err != nil {
 		return nil, err
 	}
+	input.SetValidationMethod("DNS")
 
 	var resp *svcsdk.RequestCertificateOutput
 	_ = resp


### PR DESCRIPTION
Not sure when, but at some point in the past year or so, the code generator was changed in a way that when you add fields to the `ignore` list, that field is literally `delete`d from the associated `aws-sdk-go/private/model/api.Shape` object. This means that you cannot have *both* a field that is in the `ignore` list (because you don't want it to appear in the CRD's fields) *AND* have that field referenced in the `override_values` map for an `Operation`. Because the code that sets an Input shape for an Operation iterates over the Input shape's `MemberNames()` collection, and the code generator has literally `delete`d the ignored field from the shape, meaning it cannot be referenced in the override_values code :(

This fixes an issue in the ACM controller where the `generator.yaml` file had the ValidationMethod field both ignored and in override_values by adding a `sdk_create_post_build_request` hook that manually sets the `RequestCertificateInput.ValidationMethod` field to "DNS".

Closes Issue aws-controllers-k8s/community#1701

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
