### PR TITLE
fix: env variable name fix

### DIFF
--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -91,7 +91,7 @@ spec:
           value: {{ include "watch-namespace" . }}
         - name: DELETION_POLICY
           value: {{ .Values.deletionPolicy }}
-        - name: ENABLED_LEADER_ELECTION
+        - name: ENABLE_LEADER_ELECTION
           value: {{ .Values.leaderElection.enabled | quote }}
         - name: LEADER_ELECTION_NAMESPACE
           value: {{ .Values.leaderElection.namespace | quote }}


### PR DESCRIPTION
Description of changes:

This fixes that setting and use of env variable had different names.
Without this fix leader election is always enabled in controller, but no permissions are given.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
