### PR TITLE
Add a `DomainValidations` field in `Certificate` status

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2024-01-29T07:08:03Z"
+  build_date: "2024-02-09T14:53:45Z"
   build_hash: 92f531cde5631865cfc3dfa778cbc9611f3a64c3
-  go_version: go1.21.5
+  go_version: go1.21.6
   version: v0.29.2
-api_directory_checksum: 202e02932e71256f27a9cd0f6454e508c5b7e9b6
+api_directory_checksum: eabe0fe64d57edf571ba0eb0217fc376f1185cc0
 api_version: v1alpha1
 aws_sdk_go_version: v1.49.0
 generator_config_info:
-  file_checksum: 5394dff577561d72517cec97192a6d2ea88f4244
+  file_checksum: 229489e50bc34730f31e2e0578bec6f9ea7d7215
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/certificate.go
+++ b/apis/v1alpha1/certificate.go
@@ -109,6 +109,11 @@ type CertificateStatus struct {
 	// The time at which the certificate was requested.
 	// +kubebuilder:validation:Optional
 	CreatedAt *metav1.Time `json:"createdAt,omitempty"`
+	// Contains information about the initial validation of each domain name that
+	// occurs as a result of the RequestCertificate request. This field exists only
+	// when the certificate type is AMAZON_ISSUED.
+	// +kubebuilder:validation:Optional
+	DomainValidations []*DomainValidation `json:"domainValidations,omitempty"`
 	// Contains a list of Extended Key Usage X.509 v3 extension objects. Each object
 	// specifies a purpose for which the certificate public key can be used and
 	// consists of a name and an object identifier (OID).

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -31,6 +31,8 @@ resources:
         # now deleted from the aws-sdk-go private/model/api.Shape object,
         # setting `override_values` above does not work :(
         code: input.SetValidationMethod("DNS")
+      sdk_read_one_pre_set_output:
+        template_path: hooks/certificate/sdk_read_one_pre_set_output.go.tpl
     exceptions:
       terminal_codes:
         - InvalidParameter
@@ -59,6 +61,11 @@ resources:
         from:
           operation: DescribeCertificate
           path: Certificate.CreatedAt
+      DomainValidations:
+        is_read_only: true
+        from:
+          operation: DescribeCertificate
+          path: Certificate.DomainValidationOptions
       ExtendedKeyUsages:
         is_read_only: true
         from:

--- a/apis/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/v1alpha1/zz_generated.deepcopy.go
@@ -364,6 +364,17 @@ func (in *CertificateStatus) DeepCopyInto(out *CertificateStatus) {
 		in, out := &in.CreatedAt, &out.CreatedAt
 		*out = (*in).DeepCopy()
 	}
+	if in.DomainValidations != nil {
+		in, out := &in.DomainValidations, &out.DomainValidations
+		*out = make([]*DomainValidation, len(*in))
+		for i := range *in {
+			if (*in)[i] != nil {
+				in, out := &(*in)[i], &(*out)[i]
+				*out = new(DomainValidation)
+				(*in).DeepCopyInto(*out)
+			}
+		}
+	}
 	if in.ExtendedKeyUsages != nil {
 		in, out := &in.ExtendedKeyUsages, &out.ExtendedKeyUsages
 		*out = make([]*ExtendedKeyUsage, len(*in))

--- a/config/crd/bases/acm.services.k8s.aws_certificates.yaml
+++ b/config/crd/bases/acm.services.k8s.aws_certificates.yaml
@@ -200,6 +200,41 @@ spec:
                 description: The time at which the certificate was requested.
                 format: date-time
                 type: string
+              domainValidations:
+                description: |-
+                  Contains information about the initial validation of each domain name that
+                  occurs as a result of the RequestCertificate request. This field exists only
+                  when the certificate type is AMAZON_ISSUED.
+                items:
+                  description: Contains information about the validation of each domain
+                    name in the certificate.
+                  properties:
+                    domainName:
+                      type: string
+                    resourceRecord:
+                      description: |-
+                        Contains a DNS record value that you can use to validate ownership or control
+                        of a domain. This is used by the DescribeCertificate action.
+                      properties:
+                        name:
+                          type: string
+                        type_:
+                          type: string
+                        value:
+                          type: string
+                      type: object
+                    validationDomain:
+                      type: string
+                    validationEmails:
+                      items:
+                        type: string
+                      type: array
+                    validationMethod:
+                      type: string
+                    validationStatus:
+                      type: string
+                  type: object
+                type: array
               extendedKeyUsages:
                 description: Contains a list of Extended Key Usage X.509 v3 extension
                   objects. Each object specifies a purpose for which the certificate

--- a/generator.yaml
+++ b/generator.yaml
@@ -31,6 +31,8 @@ resources:
         # now deleted from the aws-sdk-go private/model/api.Shape object,
         # setting `override_values` above does not work :(
         code: input.SetValidationMethod("DNS")
+      sdk_read_one_pre_set_output:
+        template_path: hooks/certificate/sdk_read_one_pre_set_output.go.tpl
     exceptions:
       terminal_codes:
         - InvalidParameter
@@ -59,6 +61,11 @@ resources:
         from:
           operation: DescribeCertificate
           path: Certificate.CreatedAt
+      DomainValidations:
+        is_read_only: true
+        from:
+          operation: DescribeCertificate
+          path: Certificate.DomainValidationOptions
       ExtendedKeyUsages:
         is_read_only: true
         from:

--- a/helm/crds/acm.services.k8s.aws_certificates.yaml
+++ b/helm/crds/acm.services.k8s.aws_certificates.yaml
@@ -200,6 +200,41 @@ spec:
                 description: The time at which the certificate was requested.
                 format: date-time
                 type: string
+              domainValidations:
+                description: |-
+                  Contains information about the initial validation of each domain name that
+                  occurs as a result of the RequestCertificate request. This field exists only
+                  when the certificate type is AMAZON_ISSUED.
+                items:
+                  description: Contains information about the validation of each domain
+                    name in the certificate.
+                  properties:
+                    domainName:
+                      type: string
+                    resourceRecord:
+                      description: |-
+                        Contains a DNS record value that you can use to validate ownership or control
+                        of a domain. This is used by the DescribeCertificate action.
+                      properties:
+                        name:
+                          type: string
+                        type_:
+                          type: string
+                        value:
+                          type: string
+                      type: object
+                    validationDomain:
+                      type: string
+                    validationEmails:
+                      items:
+                        type: string
+                      type: array
+                    validationMethod:
+                      type: string
+                    validationStatus:
+                      type: string
+                  type: object
+                type: array
               extendedKeyUsages:
                 description: Contains a list of Extended Key Usage X.509 v3 extension
                   objects. Each object specifies a purpose for which the certificate

--- a/pkg/resource/certificate/sdk.go
+++ b/pkg/resource/certificate/sdk.go
@@ -89,6 +89,43 @@ func (rm *resourceManager) sdkFind(
 	// Merge in the information we read from the API call above to the copy of
 	// the original Kubernetes object we passed to the function
 	ko := r.ko.DeepCopy()
+	if resp.Certificate.DomainValidationOptions != nil {
+		dvs := []*svcapitypes.DomainValidation{}
+		for _, dvsiter := range resp.Certificate.DomainValidationOptions {
+			dvselem := &svcapitypes.DomainValidation{}
+			if dvsiter.DomainName != nil {
+				dvselem.DomainName = dvsiter.DomainName
+			}
+			if dvsiter.ResourceRecord != nil {
+				dvselem.ResourceRecord = &svcapitypes.ResourceRecord{}
+				if dvsiter.ResourceRecord.Name != nil {
+					dvselem.ResourceRecord.Name = dvsiter.ResourceRecord.Name
+				}
+				if dvsiter.ResourceRecord.Type != nil {
+					dvselem.ResourceRecord.Type = dvsiter.ResourceRecord.Type
+				}
+				if dvsiter.ResourceRecord.Value != nil {
+					dvselem.ResourceRecord.Value = dvsiter.ResourceRecord.Value
+				}
+			}
+			if dvsiter.ValidationDomain != nil {
+				dvselem.ValidationDomain = dvsiter.ValidationDomain
+			}
+			if dvsiter.ValidationEmails != nil {
+				dvselem.ValidationEmails = dvsiter.ValidationEmails
+			}
+			if dvsiter.ValidationMethod != nil {
+				dvselem.ValidationMethod = dvsiter.ValidationMethod
+			}
+			if dvsiter.ValidationStatus != nil {
+				dvselem.ValidationStatus = dvsiter.ValidationStatus
+			}
+			dvs = append(dvs, dvselem)
+		}
+		ko.Status.DomainValidations = dvs
+	} else {
+		ko.Status.DomainValidations = nil
+	}
 
 	if ko.Status.ACKResourceMetadata == nil {
 		ko.Status.ACKResourceMetadata = &ackv1alpha1.ResourceMetadata{}

--- a/templates/hooks/certificate/sdk_read_one_pre_set_output.go.tpl
+++ b/templates/hooks/certificate/sdk_read_one_pre_set_output.go.tpl
@@ -1,0 +1,37 @@
+	if resp.Certificate.DomainValidationOptions != nil {
+		dvs := []*svcapitypes.DomainValidation{}
+		for _, dvsiter := range resp.Certificate.DomainValidationOptions {
+			dvselem := &svcapitypes.DomainValidation{}
+			if dvsiter.DomainName != nil {
+				dvselem.DomainName = dvsiter.DomainName
+			}
+			if dvsiter.ResourceRecord != nil {
+				dvselem.ResourceRecord = &svcapitypes.ResourceRecord{}
+				if dvsiter.ResourceRecord.Name != nil {
+					dvselem.ResourceRecord.Name = dvsiter.ResourceRecord.Name
+				}
+				if dvsiter.ResourceRecord.Type != nil {
+					dvselem.ResourceRecord.Type = dvsiter.ResourceRecord.Type
+				}
+				if dvsiter.ResourceRecord.Value != nil {
+					dvselem.ResourceRecord.Value = dvsiter.ResourceRecord.Value
+				}
+			}
+			if dvsiter.ValidationDomain != nil {
+				dvselem.ValidationDomain = dvsiter.ValidationDomain
+			}
+			if dvsiter.ValidationEmails != nil {
+				dvselem.ValidationEmails = dvsiter.ValidationEmails
+			}
+			if dvsiter.ValidationMethod != nil {
+				dvselem.ValidationMethod = dvsiter.ValidationMethod
+			}
+			if dvsiter.ValidationStatus != nil {
+				dvselem.ValidationStatus = dvsiter.ValidationStatus
+			}
+			dvs = append(dvs, dvselem)
+		}
+		ko.Status.DomainValidations = dvs
+	} else {
+		ko.Status.DomainValidations = nil
+	}


### PR DESCRIPTION
Issue aws-controllers-k8s/community1797

Description of changes:

Add a `DomainValidations` status field from the describe operation (`Certificate.DomainValidationOptions`).

Both input & output operations contains a `DomainValidationOptions` field but with different contents.
Currently the `DomainValidationOptions` in the CRD is from input and do not contains all info from the describe.
We define a new field `DomainValidations`  using [`from:`](https://aws-controllers-k8s.github.io/community/docs/contributor-docs/code-generator-config/#from-controlling-the-source-of-a-fields-definition) and a `sdk_read_one_pre_set_output` hook to populate it in order to expose these values.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
