### PR TITLE
Ignore DomainValidationOptions and keyAlgorithm deltaCompare

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2025-03-27T16:36:43Z"
-  build_hash: 980cb1e4734f673d16101cf55206b84ca639ec01
-  go_version: go1.24.1
-  version: v0.44.0
+  build_date: "2025-03-25T17:56:09Z"
+  build_hash: a326346bd3a6973254d247c9ab2dc76790c36241
+  go_version: go1.24.0
+  version: v0.43.2
 api_directory_checksum: 06c3fd0ed69ec69d489b2ca1582a2b21caaf2ad5
 api_version: v1alpha1
 aws_sdk_go_version: v1.32.6
 generator_config_info:
-  file_checksum: 38b3144fc024675b7bdccb9141fc36779effb946
+  file_checksum: 345353735b9c45f5f9a2d9a7279e7967673e84ab
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2025-03-25T17:56:09Z"
-  build_hash: a326346bd3a6973254d247c9ab2dc76790c36241
-  go_version: go1.24.0
-  version: v0.43.2
-api_directory_checksum: 06c3fd0ed69ec69d489b2ca1582a2b21caaf2ad5
+  build_date: "2025-04-03T18:41:21Z"
+  build_hash: 980cb1e4734f673d16101cf55206b84ca639ec01
+  go_version: go1.24.1
+  version: v0.44.0
+api_directory_checksum: c81e9094002706a6f7db72617aa0348cb7e53dd5
 api_version: v1alpha1
 aws_sdk_go_version: v1.32.6
 generator_config_info:
-  file_checksum: 345353735b9c45f5f9a2d9a7279e7967673e84ab
+  file_checksum: 1489a54e7f1a1b28f8b44e738c239b03b364f74a
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/certificate.go
+++ b/apis/v1alpha1/certificate.go
@@ -57,6 +57,7 @@ type CertificateSpec struct {
 	DomainName *string `json:"domainName,omitempty"`
 	// The domain name that you want ACM to use to send you emails so that you can
 	// validate domain ownership.
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable once set"
 	DomainValidationOptions []*DomainValidationOption `json:"domainValidationOptions,omitempty"`
 	// Specifies the algorithm of the public and private key pair that your certificate
 	// uses to encrypt data. RSA is the default key algorithm for ACM certificates.
@@ -84,6 +85,7 @@ type CertificateSpec struct {
 	// must match the algorithm family of the CA's secret key.
 	//
 	// Default: RSA_2048
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable once set"
 	KeyAlgorithm *string `json:"keyAlgorithm,omitempty"`
 	// Currently, you can use this parameter to specify whether to add the certificate
 	// to a certificate transparency log. Certificate transparency makes it possible

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -85,6 +85,8 @@ resources:
         is_immutable: true
       KeyAlgorithm:
         late_initialize: {}
+        compare:
+          is_ignored: true 
       Options:
         late_initialize: {}
       # NOTE(jaypipes): The Create operation (RequestCertificate) has a
@@ -102,6 +104,9 @@ resources:
         from:
           operation: DescribeCertificate
           path: Certificate.DomainValidationOptions
+      DomainValidationOptions:
+        compare:
+          is_ignored: true
       ExtendedKeyUsages:
         is_read_only: true
         from:

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -85,8 +85,9 @@ resources:
         is_immutable: true
       KeyAlgorithm:
         late_initialize: {}
+        is_immutable: true
         compare:
-          is_ignored: true 
+          is_ignored: true
       Options:
         late_initialize: {}
       # NOTE(jaypipes): The Create operation (RequestCertificate) has a
@@ -105,6 +106,7 @@ resources:
           operation: DescribeCertificate
           path: Certificate.DomainValidationOptions
       DomainValidationOptions:
+        is_immutable: true
         compare:
           is_ignored: true
       ExtendedKeyUsages:

--- a/config/crd/bases/acm.services.k8s.aws_certificates.yaml
+++ b/config/crd/bases/acm.services.k8s.aws_certificates.yaml
@@ -152,6 +152,9 @@ spec:
                       type: string
                   type: object
                 type: array
+                x-kubernetes-validations:
+                - message: Value is immutable once set
+                  rule: self == oldSelf
               keyAlgorithm:
                 description: |-
                   Specifies the algorithm of the public and private key pair that your certificate
@@ -181,6 +184,9 @@ spec:
 
                   Default: RSA_2048
                 type: string
+                x-kubernetes-validations:
+                - message: Value is immutable once set
+                  rule: self == oldSelf
               options:
                 description: |-
                   Currently, you can use this parameter to specify whether to add the certificate

--- a/generator.yaml
+++ b/generator.yaml
@@ -85,6 +85,8 @@ resources:
         is_immutable: true
       KeyAlgorithm:
         late_initialize: {}
+        compare:
+          is_ignored: true 
       Options:
         late_initialize: {}
       # NOTE(jaypipes): The Create operation (RequestCertificate) has a
@@ -102,6 +104,9 @@ resources:
         from:
           operation: DescribeCertificate
           path: Certificate.DomainValidationOptions
+      DomainValidationOptions:
+        compare:
+          is_ignored: true
       ExtendedKeyUsages:
         is_read_only: true
         from:

--- a/generator.yaml
+++ b/generator.yaml
@@ -85,8 +85,9 @@ resources:
         is_immutable: true
       KeyAlgorithm:
         late_initialize: {}
+        is_immutable: true
         compare:
-          is_ignored: true 
+          is_ignored: true
       Options:
         late_initialize: {}
       # NOTE(jaypipes): The Create operation (RequestCertificate) has a
@@ -105,6 +106,7 @@ resources:
           operation: DescribeCertificate
           path: Certificate.DomainValidationOptions
       DomainValidationOptions:
+        is_immutable: true
         compare:
           is_ignored: true
       ExtendedKeyUsages:

--- a/helm/crds/acm.services.k8s.aws_certificates.yaml
+++ b/helm/crds/acm.services.k8s.aws_certificates.yaml
@@ -152,6 +152,9 @@ spec:
                       type: string
                   type: object
                 type: array
+                x-kubernetes-validations:
+                - message: Value is immutable once set
+                  rule: self == oldSelf
               keyAlgorithm:
                 description: |-
                   Specifies the algorithm of the public and private key pair that your certificate
@@ -181,6 +184,9 @@ spec:
 
                   Default: RSA_2048
                 type: string
+                x-kubernetes-validations:
+                - message: Value is immutable once set
+                  rule: self == oldSelf
               options:
                 description: |-
                   Currently, you can use this parameter to specify whether to add the certificate

--- a/pkg/resource/certificate/delta.go
+++ b/pkg/resource/certificate/delta.go
@@ -67,20 +67,6 @@ func newResourceDelta(
 			delta.Add("Spec.DomainName", a.ko.Spec.DomainName, b.ko.Spec.DomainName)
 		}
 	}
-	if len(a.ko.Spec.DomainValidationOptions) != len(b.ko.Spec.DomainValidationOptions) {
-		delta.Add("Spec.DomainValidationOptions", a.ko.Spec.DomainValidationOptions, b.ko.Spec.DomainValidationOptions)
-	} else if len(a.ko.Spec.DomainValidationOptions) > 0 {
-		if !reflect.DeepEqual(a.ko.Spec.DomainValidationOptions, b.ko.Spec.DomainValidationOptions) {
-			delta.Add("Spec.DomainValidationOptions", a.ko.Spec.DomainValidationOptions, b.ko.Spec.DomainValidationOptions)
-		}
-	}
-	if ackcompare.HasNilDifference(a.ko.Spec.KeyAlgorithm, b.ko.Spec.KeyAlgorithm) {
-		delta.Add("Spec.KeyAlgorithm", a.ko.Spec.KeyAlgorithm, b.ko.Spec.KeyAlgorithm)
-	} else if a.ko.Spec.KeyAlgorithm != nil && b.ko.Spec.KeyAlgorithm != nil {
-		if *a.ko.Spec.KeyAlgorithm != *b.ko.Spec.KeyAlgorithm {
-			delta.Add("Spec.KeyAlgorithm", a.ko.Spec.KeyAlgorithm, b.ko.Spec.KeyAlgorithm)
-		}
-	}
 	if ackcompare.HasNilDifference(a.ko.Spec.Options, b.ko.Spec.Options) {
 		delta.Add("Spec.Options", a.ko.Spec.Options, b.ko.Spec.Options)
 	} else if a.ko.Spec.Options != nil && b.ko.Spec.Options != nil {


### PR DESCRIPTION
Issue [#2395](https://github.com/aws-controllers-k8s/community/issues/2395)

Description of changes:
The DomainValidationOptions are returned with arbitrary order. Removing
comparison completely since there is no update operation to change it.

Same goes for keyAlgorithm

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
