### PR TITLE
fix: use an allowed domain for AcmeDomainValidation e2e tests

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2026-08-13T00:54:52Z"
-  build_hash: 65d45b2e6c9efd6aca20e0d36826d1e18e4ba2b7
-  go_version: go1.26.5
-  version: v0.62.1
+  build_date: "2026-09-09T17:11:11Z"
+  build_hash: 3da9ce283716fa8d0046dc18eeb1a79a9e6fb1a0
+  go_version: go1.27.1
+  version: v0.63.0-8-g3da9ce2
 api_directory_checksum: 72367ce5aec8fbf72e4df91cf436dae34b7b522b
 api_version: v1alpha1
 aws_service_sdk_version: v1.42.0
 generator_config_info:
-  file_checksum: 05ff6c636bf30bba4685478aa18ebc17eac994c6
+  file_checksum: a71482fb26b7c5367e58aed8c2357bee7420754b
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/certificate.go
+++ b/apis/v1alpha1/certificate.go
@@ -79,11 +79,11 @@ type CertificateSpec struct {
 	//
 	// Algorithms supported for an ACM certificate request include:
 	//
-	//   - RSA_2048
+	//    * RSA_2048
 	//
-	//   - EC_prime256v1
+	//    * EC_prime256v1
 	//
-	//   - EC_secp384r1
+	//    * EC_secp384r1
 	//
 	// Other listed algorithms are for imported certificates only.
 	//
@@ -124,17 +124,16 @@ type CertificateSpec struct {
 	// multiple labels separated by periods. No label can be longer than 63 octets.
 	// Consider the following examples:
 	//
-	//   - (63 octets).(63 octets).(63 octets).(61 octets) is legal because the
-	//     total length is 253 octets (63+1+63+1+63+1+61) and no label exceeds 63
-	//     octets.
+	//    * (63 octets).(63 octets).(63 octets).(61 octets) is legal because the
+	//    total length is 253 octets (63+1+63+1+63+1+61) and no label exceeds 63
+	//    octets.
 	//
-	//   - (64 octets).(63 octets).(63 octets).(61 octets) is not legal because
-	//     the total length exceeds 253 octets (64+1+63+1+63+1+61) and the first
-	//     label exceeds 63 octets.
+	//    * (64 octets).(63 octets).(63 octets).(61 octets) is not legal because
+	//    the total length exceeds 253 octets (64+1+63+1+63+1+61) and the first
+	//    label exceeds 63 octets.
 	//
-	//   - (63 octets).(63 octets).(63 octets).(62 octets) is not legal because
-	//     the total length of the DNS name (63+1+63+1+63+1+62) exceeds 253 octets.
-	//
+	//    * (63 octets).(63 octets).(63 octets).(62 octets) is not legal because
+	//    the total length of the DNS name (63+1+63+1+63+1+62) exceeds 253 octets.
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable once set"
 	SubjectAlternativeNames []*string `json:"subjectAlternativeNames,omitempty"`
 	// One or more resource tags to associate with the certificate.

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -267,6 +267,7 @@ resources:
         - InvalidTagException
         - TagPolicyException
         - TooManyTagsException
+        - ValidationException
     reconcile:
       requeue_on_success_seconds: 30
     synced:
@@ -329,6 +330,7 @@ resources:
         - InvalidTagException
         - TagPolicyException
         - TooManyTagsException
+        - ValidationException
     # Treat a domain validation as a point-in-time health check, not a resource
     # with a terminal state:
     #   VALID    -> Synced=True, re-checked at the controller resync period
@@ -424,6 +426,7 @@ resources:
         - InvalidTagException
         - TagPolicyException
         - TooManyTagsException
+        - ValidationException
     # A short requeue keeps the server-side status fields (lastUsedAt, revokedAt,
     # expiresAt) close to reality, since the service changes them without any spec edit
     # to trigger a reconcile. Same interval as Certificate above; AcmeEndpoint uses 30s.

--- a/generator.yaml
+++ b/generator.yaml
@@ -267,6 +267,7 @@ resources:
         - InvalidTagException
         - TagPolicyException
         - TooManyTagsException
+        - ValidationException
     reconcile:
       requeue_on_success_seconds: 30
     synced:
@@ -329,6 +330,7 @@ resources:
         - InvalidTagException
         - TagPolicyException
         - TooManyTagsException
+        - ValidationException
     # Treat a domain validation as a point-in-time health check, not a resource
     # with a terminal state:
     #   VALID    -> Synced=True, re-checked at the controller resync period
@@ -424,6 +426,7 @@ resources:
         - InvalidTagException
         - TagPolicyException
         - TooManyTagsException
+        - ValidationException
     # A short requeue keeps the server-side status fields (lastUsedAt, revokedAt,
     # expiresAt) close to reality, since the service changes them without any spec edit
     # to trigger a reconcile. Same interval as Certificate above; AcmeEndpoint uses 30s.

--- a/helm/crds/acm.services.k8s.aws_certificates.yaml
+++ b/helm/crds/acm.services.k8s.aws_certificates.yaml
@@ -200,11 +200,11 @@ spec:
 
                   Algorithms supported for an ACM certificate request include:
 
-                    - RSA_2048
+                     * RSA_2048
 
-                    - EC_prime256v1
+                     * EC_prime256v1
 
-                    - EC_secp384r1
+                     * EC_secp384r1
 
                   Other listed algorithms are for imported certificates only.
 
@@ -279,16 +279,16 @@ spec:
                   multiple labels separated by periods. No label can be longer than 63 octets.
                   Consider the following examples:
 
-                    - (63 octets).(63 octets).(63 octets).(61 octets) is legal because the
-                      total length is 253 octets (63+1+63+1+63+1+61) and no label exceeds 63
-                      octets.
+                     * (63 octets).(63 octets).(63 octets).(61 octets) is legal because the
+                     total length is 253 octets (63+1+63+1+63+1+61) and no label exceeds 63
+                     octets.
 
-                    - (64 octets).(63 octets).(63 octets).(61 octets) is not legal because
-                      the total length exceeds 253 octets (64+1+63+1+63+1+61) and the first
-                      label exceeds 63 octets.
+                     * (64 octets).(63 octets).(63 octets).(61 octets) is not legal because
+                     the total length exceeds 253 octets (64+1+63+1+63+1+61) and the first
+                     label exceeds 63 octets.
 
-                    - (63 octets).(63 octets).(63 octets).(62 octets) is not legal because
-                      the total length of the DNS name (63+1+63+1+63+1+62) exceeds 253 octets.
+                     * (63 octets).(63 octets).(63 octets).(62 octets) is not legal because
+                     the total length of the DNS name (63+1+63+1+63+1+62) exceeds 253 octets.
                 items:
                   type: string
                 type: array

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -197,3 +197,5 @@ featureGates:
   ResourceAdoption: true
   # Enable IAMRoleSelector, a multirole feature, replacing CARM. See https://github.com/aws-controllers-k8s/community/pull/2628
   IAMRoleSelector: false
+  # Enable IgnoreFieldDrift, services.k8s.aws/ignore-field-drift annotation. See https://aws-controllers-k8s.github.io/docs/guides/ignore-field-drift
+  IgnoreFieldDrift: false

--- a/pkg/resource/acme_domain_validation/sdk.go
+++ b/pkg/resource/acme_domain_validation/sdk.go
@@ -591,7 +591,8 @@ func (rm *resourceManager) terminalAWSError(err error) bool {
 		"InvalidArnException",
 		"InvalidTagException",
 		"TagPolicyException",
-		"TooManyTagsException":
+		"TooManyTagsException",
+		"ValidationException":
 		return true
 	default:
 		return false

--- a/pkg/resource/acme_endpoint/sdk.go
+++ b/pkg/resource/acme_endpoint/sdk.go
@@ -575,7 +575,8 @@ func (rm *resourceManager) terminalAWSError(err error) bool {
 		"InvalidArnException",
 		"InvalidTagException",
 		"TagPolicyException",
-		"TooManyTagsException":
+		"TooManyTagsException",
+		"ValidationException":
 		return true
 	default:
 		return false

--- a/pkg/resource/acme_external_account_binding/sdk.go
+++ b/pkg/resource/acme_external_account_binding/sdk.go
@@ -494,7 +494,8 @@ func (rm *resourceManager) terminalAWSError(err error) bool {
 		"InvalidArnException",
 		"InvalidTagException",
 		"TagPolicyException",
-		"TooManyTagsException":
+		"TooManyTagsException",
+		"ValidationException":
 		return true
 	default:
 		return false

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -27,6 +27,6 @@ var (
 // that generated this controller's code. They are baked in at code-generation
 // time and are immutable for the life of the generated code.
 const (
-	ACKGenerateVersion   = "v0.62.1"
-	ACKGenerateBuildDate = "2026-08-13T00:54:52Z"
+	ACKGenerateVersion   = "v0.63.0-8-g3da9ce2"
+	ACKGenerateBuildDate = "2026-09-09T17:11:11Z"
 )

--- a/test/e2e/tests/test_acme.py
+++ b/test/e2e/tests/test_acme.py
@@ -41,6 +41,8 @@ CREATE_EAB_WAIT_SECONDS = 65
 UPDATE_WAIT_SECONDS = 35
 # A credential repair happens on the resource's next read, so allow for more than one requeue
 REPAIR_WAIT_SECONDS = 120
+# ACM ACME only lets internal AWS accounts validate .people.aws.dev subdomains
+DOMAIN_VALIDATION_PARENT_DOMAIN = 'people.aws.dev'
 
 
 def _aws_resource_tags(acm_client, resource_arn: str) -> Dict[str, str]:
@@ -184,11 +186,12 @@ def acme_domain_validation(request, acme_endpoint) -> Tuple[k8s.CustomResourceRe
     endpoint_arn = endpoint_cr["status"]["ackResourceMetadata"]["arn"]
 
     validation_name = random_suffix_name("acme-dv", 20)
+    domain_name = f"{validation_name}.{DOMAIN_VALIDATION_PARENT_DOMAIN}"
 
     replacements = REPLACEMENT_VALUES.copy()
     replacements['ACME_DOMAIN_VALIDATION_NAME'] = validation_name
     replacements['ACME_ENDPOINT_ARN'] = endpoint_arn
-    replacements['DOMAIN_NAME'] = 'example.com'
+    replacements['DOMAIN_NAME'] = domain_name
 
     resource_data = load_resource(
         "acme_domain_validation",
@@ -240,8 +243,8 @@ class TestAcmeDomainValidation:
     def test_create_delete(self, acme_domain_validation, acm_client):
         (ref, cr) = acme_domain_validation
 
-        # Poll until the validation settles. example.com cannot be validated,
-        # so it lands INVALID.
+        # Poll until the validation settles. The domain has no DNS records, so
+        # it lands INVALID.
         status = _wait_for_settled_dv_status(ref)
 
         # Re-read to get updated status
@@ -291,8 +294,8 @@ class TestAcmeDomainValidation:
         time.sleep(UPDATE_WAIT_SECONDS)
 
         # The update should reconcile fully and the validation should settle
-        # again (INVALID for example.com). Note ACK.ResourceSynced is only True
-        # for VALID, so we poll the status instead of the condition.
+        # again (INVALID). Note ACK.ResourceSynced is only True for VALID, so we
+        # poll the status instead of the condition.
         _wait_for_settled_dv_status(ref)
 
         # Verify against AWS. The describe response reports the effective


### PR DESCRIPTION
Description of changes:
ACM ACME now rejects domain validations from internal AWS accounts unless the
domain ends in .people.aws.dev or .people.amazon.dev, so the example.com fixture
fails to create at all. Also mark ValidationException terminal for the ACME
resources so a permanent 400 stops retrying.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
